### PR TITLE
update options --list-rules

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { version } from '../package.json';
 import { analyzeFile } from "./parser";
+import { ALL_RULES } from "./rules";
 
 const program = new Command();
 
@@ -18,11 +19,20 @@ program
   .option('-l, --list-rules', 'List all available rules')
   .action(async (filePath: string, options: any) => {
     console.log('filePath: ', filePath);
-    console.log('options:', options);
+    // console.log('options:', options, options.rules);
+
+    if (options.listRules) {
+      console.log(chalk.bold('\n📋 Available Rules:\n'));
+      ALL_RULES.forEach(ruleClass => {
+        const rule = new ruleClass({} as any);
+        console.log(chalk.whiteBright.bold(`  •  `) + chalk.yellow(`${rule.getName()}`));
+        console.log(chalk.gray(`    ${rule.getDescription()}\n`));
+      });
+      return;
+    }
 
     console.log(chalk.blue('='.repeat(50)));
     console.log(chalk.blue(`🔍 Analyzing ${filePath}...`));
-    console.log('')
 
     try {
       await analyzeFile(filePath);


### PR DESCRIPTION
แสดง list rules เมื่อใช้ options --list-rules
Display the list of rules when using the --list-rules option.

## Summary by Sourcery

Implement the `--list-rules` flag in the CLI to print a formatted list of all linting rules and exit before running analysis.

New Features:
- Add `--list-rules` CLI option to display all available rules

Enhancements:
- Import `ALL_RULES` and iterate through each rule to show its name and description
- Format the rule list output with chalk styling for better readability